### PR TITLE
fix: load task->cred once to satisfy BPF verifier RCU pointer tracking

### DIFF
--- a/ebpf/co-re/co-re.h
+++ b/ebpf/co-re/co-re.h
@@ -127,8 +127,9 @@ inline const struct task_struct *task_struct_real_parent(const struct task_struc
 }
 
 inline uid_t task_struct_uid(const struct task_struct *task) {
-	if (task->cred != 0) {
-		return task->cred->uid.val;
+	const struct cred *c = task->cred;
+	if (c != 0) {
+		return c->uid.val;
 	} else {
 		return 0;
 	}


### PR DESCRIPTION
The BPF verifier on newer kernels tracks each memory load of an RCU-protected pointer independently. task_struct_uid() loaded task->cred twice: once for the null check and once for the dereference. The verifier treated the second load as a fresh rcu_ptr_or_null_cred whose null state was unknown, rejecting the program with 'R1 invalid mem access rcu_ptr_or_null_'.

Store task->cred in a local variable so the null check and dereference operate on the same verifier-tracked value.