### PR TITLE
Increase ebpf ring buffer to 1 MB

### DIFF
--- a/ebpf/src/event_queue.rs
+++ b/ebpf/src/event_queue.rs
@@ -5,7 +5,7 @@ use aya_ebpf::{macros::map, maps::RingBuf};
 use common::event::Event;
 
 #[map]
-static EVENT_QUEUE: RingBuf = RingBuf::with_byte_size(100000, 0);
+static EVENT_QUEUE: RingBuf = RingBuf::with_byte_size(1048576, 0);
 
 /// Calls `initializer` to initialize the uninitialized event. If the initializer returns
 /// true, the event is enqueued, if it returns false, it is discarded.


### PR DESCRIPTION
This should decrease the chance of overflows and silent event drops during traffic bursts (like intensive browser page loads), new value is also a clean power of 2, so that the kernel is not rounding it up itself.

Memory cost seems negligible in this case.

